### PR TITLE
Слегка подправил размер персика

### DIFF
--- a/src/pages/home/persik/index.ts
+++ b/src/pages/home/persik/index.ts
@@ -1,0 +1,1 @@
+export * from './persik';

--- a/src/pages/home/persik/persik.module.css
+++ b/src/pages/home/persik/persik.module.css
@@ -1,0 +1,6 @@
+.persik {
+    display: block;
+    width: 70%;
+    max-width: 500px;
+    margin: 20px auto;
+}

--- a/src/pages/home/persik/persik.tsx
+++ b/src/pages/home/persik/persik.tsx
@@ -9,6 +9,8 @@ import {
   PanelHeaderBack
 } from '@vkontakte/vkui';
 
+import styles from './persik.module.css';
+
 export const Persik: FC<NavIdProps> = ({ nav }) => {
   return (
     <Panel nav={nav}>
@@ -18,7 +20,7 @@ export const Persik: FC<NavIdProps> = ({ nav }) => {
 
       <Group>
         <Div>
-          <img src="/persik.png" />
+          <img className={styles.persik} src="/persik.png" />
         </Div>
       </Group>
     </Panel>


### PR DESCRIPTION
За основу взяты стили персика из официального ВКшного темплейта и слегка подредактированы для большей видимости. Теперь картинка с ним не вылазит за края на мобильных устройствах

## До

![image](https://user-images.githubusercontent.com/36604233/191100048-9f9e4dbc-c8ff-4b3d-ae4a-3a4c7f40974f.png)
![image](https://user-images.githubusercontent.com/36604233/191100058-5b75fb57-da3e-4fb0-9f96-ba62917f08a6.png)

## После

![image](https://user-images.githubusercontent.com/36604233/191100144-c1fc62c9-380d-4333-bd9d-bfdc9b721e78.png)
![image](https://user-images.githubusercontent.com/36604233/191100122-a90d1bf0-81a2-4ccb-912d-0188d9b0948a.png)
