### PR TITLE
Фикс стилей градиента на домашней странице

### DIFF
--- a/src/pages/home/home/home.module.css
+++ b/src/pages/home/home/home.module.css
@@ -1,5 +1,5 @@
-.gradient {
-  margin: -7px auto 7px;
+:global(.vkuiGradient).gradient {
+  margin: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8,16 +8,16 @@
   padding: 32px;
 }
 
-.gradient-desktop {
-  margin: -7px -7px 7px -7px;
+:global(.vkuiGradient).gradient-desktop {
+  margin: -7px -7px 0 -7px;
 }
 
-.gradient-title {
+:global(.vkuiTitle).gradient-title {
   margin-bottom: 8px;
   margin-top: 20px;
 }
 
-.gradient-secondary {
-  margin-bottom: 24px; 
+:global(.vkuiText).gradient-secondary {
+  margin-bottom: 24px;
   color: var(--text_secondary);
 }


### PR DESCRIPTION
Данный фикс правит момент с CSS Modules, когда он не переопределяет стили UI-библиотеки, из-за чего кастомные стили просто игнорятся

#### Пример до:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/36604233/192154820-3cce0fbe-c061-4dfd-9ccc-ed313b103003.png">

#### Пример после:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/36604233/192154805-e97e50e0-5246-4928-8063-b82cf687f01e.png">

#### Пример из документации:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/36604233/192154831-2b0e98a6-5d6a-412b-8129-6995a9cab3dd.png">

При помощи использования `:global(.названиеКласса)`, кастомные стили начинают работать как надо. Это изменение также поможет тем, кто начнет использовать (или уже использует) этот темплейт, дабы починить подобные проблемы в будущем

> P.S. Еще немного поправил паддинги для градиента, взяв их из `const styles = ...` в https://vkcom.github.io/VKUI/#/Gradient